### PR TITLE
fix ON key value

### DIFF
--- a/OSLoader/HAL/keyboard_up.c
+++ b/OSLoader/HAL/keyboard_up.c
@@ -47,9 +47,8 @@ void key_task_capt()
             if(ck == KEY_ON && cp)
             {
                 state = 1;
-            }else{
-                g_latest_key_status = kval;
             }
+            g_latest_key_status = kval;
             break;
         
         case 1:
@@ -57,7 +56,7 @@ void key_task_capt()
             {
                 state = 0;
                 capt_ck = 0;
-                g_latest_key_status = (1 << 16) | KEY_ON;
+                g_latest_key_status = (0 << 16) | KEY_ON;
             }else if(ck != KEY_ON && cp){
                 state = 2;
                 capt_ck = ck;


### PR DESCRIPTION
修复的问题:
ON按键和其它按键不一样。
ON按键按下时键值不会变化，松开时键值变成<ON按下>，然后再也不会变成ON松开了。

修复后不影响ON+快捷键，同时让ON和其它按键一样，按下时键值变成<ON按下>的，松开时键值变成<ON松开>的

The ON key is different from other keys.
When ON is pressed, the key value will not change. And when it is released, the key value become <PRESSED | ON>.

After this commit, when ON is pressed, the key value become <PRESSED | ON>, and when ON is released, the key value become <RELEASED | ON>